### PR TITLE
Iterate all node lists with index, not item().

### DIFF
--- a/pinboard-particular.js
+++ b/pinboard-particular.js
@@ -64,7 +64,7 @@ var selectFromNodeList = function(nodeList,func,thisObj) {
   var l = nodeList.length;
   var result;
   for(var i=0;i<l;++i) {
-    result = func.call(thisObj,nodeList.item(i));
+    result = func.call(thisObj,nodeList[i]);
     if(result !== null) {
       return result;
     }


### PR DESCRIPTION
`getElementsByTagName()` returns a node list that implements `item()`, but `getElementsByClassName()`
just returns a plain array that does not. This means the bookmarklet doesn't work for any pages with
`hentry` classes.
