### PR TITLE
Fix for GitHub description field

### DIFF
--- a/pinboard-particular.js
+++ b/pinboard-particular.js
@@ -32,6 +32,7 @@ var titleTweaks = {
 
 // this matches domain names to special selectors for the title
 var descriptionTweaks = {
+  "github.com":"[itemprop='about']",
   "www.kickstarter.com":".short-blurb"
 };
 


### PR DESCRIPTION
Recently GitHub started putting a generic meta description field:

> GitHub is where people build software.
> More than 27 million people use GitHub to discover, fork, and contribute to over 80 million projects.

This fixes it.